### PR TITLE
'dict' object has no attribute 'append'

### DIFF
--- a/avea/avea.py
+++ b/avea/avea.py
@@ -221,7 +221,7 @@ def discover_avea_bulbs():
     This method requires the script to be launched as root
     Returns the list of nearby bulbs
     """
-    bulb_list = {}
+    bulb_list = []
     from bluepy.btle import Scanner, DefaultDelegate
 
     class ScanDelegate(DefaultDelegate):


### PR DESCRIPTION
```
019-04-20 15:52:55 ERROR (MainThread) [homeassistant.components.light] Error while setting up platform avea
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/homeassistant/helpers/entity_platform.py", line 126, in _async_setup_platform
    SLOW_SETUP_MAX_WAIT, loop=hass.loop)
  File "/usr/local/lib/python3.7/asyncio/tasks.py", line 416, in wait_for
    return fut.result()
  File "/usr/local/lib/python3.7/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/config/custom_components/avea/light.py", line 28, in setup_platform
    nearbyBulbs = avea.discover_avea_bulbs()
  File "/config/deps/lib/python3.7/site-packages/avea/avea.py", line 239, in discover_avea_bulbs
    bulb_list.append(Bulb(dev.addr))
AttributeError: 'dict' object has no attribute 'append'
```