### PR TITLE
Add release.published and manual workflow dispatch for Python publish

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,11 +1,12 @@
-# This workflows will upload a Python Package using Twine when a release is created
+# This workflow will upload a Python Package using Twine when a release is created or published
 # For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
 
 name: Upload Python Package
 
 on:
   release:
-    types: [created]
+    types: [created, published]
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
This PR updates the GitHub Actions trigger for the python-publish workflow:

- Reacts to release: published in addition to created (so publishing a previously created Draft is covered).
- Adds workflow_dispatch so the workflow can be started manually from the Actions UI.

Why: Releasing a draft triggers release.published (not release.created), which prevented the workflow from running for v1.6.0. This change covers both cases and allows manual runs.

Should resolve #22 by aligning workflow triggers with GitHub’s release event behaviour.