### PR TITLE
Relax bleak requirement to support HA's pin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
         "Operating System :: POSIX :: Linux",
     ],
     install_requires=[
-        'bleak>=1.1.1',
+        'bleak>=1.0.0',
         'bleak-retry-connector>=4.4.3',
     ],
     python_requires=">=3.9,<4",


### PR DESCRIPTION
## Summary

- lower the package requirement to `bleak>=1.0.0` so the Avea package installs cleanly in environments (like Home Assistant) that pin bleak to 1.0.1
- keep the existing `bleak-retry-connector>=4.4.3` requirement and Python version constraints from 1.6.0

This change has no impact on the library’s functionality—Avea only uses APIs that already exist in bleak 1.0.x—so compatibility with Home Assistant is restored without any further code adjustments.