### PR TITLE
Fix version inconsistencies for Bleak dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     classifiers=[
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
@@ -24,8 +23,8 @@ setuptools.setup(
         "Operating System :: POSIX :: Linux",
     ],
     install_requires=[
-        'bleak>=1.0.0',
-        'bleak-retry-connector>=4.4.3',
+        "bleak>=1.0.0",
+        "bleak-retry-connector>=4.4.3",
     ],
-    python_requires=">=3.9,<4",
+    python_requires=">=3.10,<4",
 )

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
     ],
     install_requires=[
         "bleak>=1.0.0",
-        "bleak-retry-connector>=4.4.3",
+        "bleak-retry-connector>=4.0.0",
     ],
     python_requires=">=3.10,<4",
 )


### PR DESCRIPTION
Align `setup.py` with the Bleak 1.x ecosystem by:
- raising `python_requires` to `>=3.10,<4` so the dependency metadata matches the interpreter floor required by `bleak-retry-connector>=4.0.0`.
- loosening `bleak-retry-connector` to `>=4.0.0`, which is the release that added Bleak 1.x support while still installing cleanly on Python 3.10.
