### PR TITLE
Codex/set version in one place

### DIFF
--- a/avea/__init__.py
+++ b/avea/__init__.py
@@ -2,5 +2,5 @@
 
 A python library to control Elgato's Avea Bulb.
 """
-__version__ = "1.5.2"
+__version__ = "1.6.1"
 from .avea import *

--- a/avea/avea.py
+++ b/avea/avea.py
@@ -2,7 +2,6 @@
 Creator : k0rventen
 License : MIT
 Source  : https://github.com/k0rventen/avea
-Version : 1.5.2
 """
 
 import asyncio

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,26 @@
+from pathlib import Path
+import re
+
 import setuptools
 
+ROOT = Path(__file__).parent
 
-with open("README.md", "r") as fh:
+with open(ROOT / "README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
+
+init_text = (ROOT / "avea" / "__init__.py").read_text(encoding="utf-8")
+version_match = re.search(
+    r'^__version__\s*=\s*[\'"]([^\'"]+)[\'"]\s*$',
+    init_text,
+    re.MULTILINE,
+)
+if version_match is None:
+    raise RuntimeError("Unable to find __version__ in avea/__init__.py")
+version = version_match.group(1)
 
 setuptools.setup(
     name="avea",
-    version="1.6.1",
+    version=version,
     author="k0rventen",
     description="Control an Elgato Avea bulb using python3",
     long_description=long_description,


### PR DESCRIPTION
## Summary

This PR makes `avea/__init__.py` the single canonical source for the package version and removes duplicated stale version metadata.

## Changes

- Keeps `__version__` in `avea/__init__.py` as the canonical package version.
- Updates `setup.py` to read the version from `avea/__init__.py` instead of hard-coding it.
- Removes the stale `Version : 1.5.2` header from `avea/avea.py`.

## Validation

- Confirmed `python setup.py --version` returns the package version from `avea/__init__.py`.
- Confirmed `import avea; print(avea.__version__)` returns the same version.
- Checked README/release-note references for stale version mentions.
