### PR TITLE
Update CI validation for Python tests

### DIFF
--- a/.github/workflows/ci-validation.yml
+++ b/.github/workflows/ci-validation.yml
@@ -8,30 +8,25 @@ on:
 
 jobs:
   test:
-    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == github.event.repository.default_branch)
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel
-          pip install -e .
-          pip install pytest
+          python -m pip install -e . pytest
 
-      # - name: Run tests
-      #   run: python -m pytest
-      # TODO: Add tests that exercise the package so pytest can run here before re-enabling this step.
+      - name: Run tests
+        run: python -m pytest
 
-      # Build step is the current priority; it verifies packaging succeeds so we can re-enable tests later.
       - name: Build distribution
         run: python setup.py sdist bdist_wheel

--- a/.github/workflows/ci-validation.yml
+++ b/.github/workflows/ci-validation.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e . pytest
+          python -m pip install -e . pytest setuptools wheel
 
       - name: Run tests
         run: python -m pytest


### PR DESCRIPTION
## Summary

- simplify the CI Validation workflow so it runs on every push and pull request
- enable the Python test step with `python -m pytest`
- add Python 3.13 to the CI matrix
- update `actions/setup-python` from `v4` to `v5`
- keep the distribution build check after the test run

## Motivation

The repository now has Python tests in `tests/test_logging.py`, so CI should execute them instead of only building the package. The previous job-level `if` condition made the workflow harder to reason about and skipped push validation outside the default branch.

## Validation

- `.venv/bin/python -m pip install -e . pytest`
- `.venv/bin/python -m pytest`
  - `6 passed`
- `.venv/bin/python setup.py sdist bdist_wheel`

## Notes

This branch is rebased on the current upstream `master` and includes the upstream test suite before applying the workflow change.
