### PR TITLE
Add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 2
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

- Add a minimal Dependabot configuration for GitHub Actions.
- Run updates monthly and group action updates into a single PR.
- Limit open Dependabot PRs to two to keep maintenance noise low.

## Impact

This keeps workflow action versions current without changing Python dependency management. Python package updates are intentionally left out because this repo currently declares runtime dependencies in `setup.py` with broad lower bounds.

## Validation

- Parsed `.github/dependabot.yml` with Ruby YAML loader.