### PR TITLE
Add manufacturer name accessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ theRgbColor = myBulb.get_rgb()          # Query the bulb in a RGB format
 theBrightness = myBulb.get_brightness() # query the current brightness
 theAddr = myBulb.addr                   # query the bulb Bluetooth addr
 theFwVersion = myBulb.get_fw_version()  # query the bulb firmware version
+theManufacturerName = myBulb.get_manufacturer_name()  # query the bulb manufacturer name
 ```
 
 That's it. Pretty simple.

--- a/avea/avea.py
+++ b/avea/avea.py
@@ -26,6 +26,7 @@ __all__ = [
 ]
 
 FIRMWARE_REVISION_UUID = "00002a26-0000-1000-8000-00805f9b34fb"
+MANUFACTURER_NAME_UUID = "00002a29-0000-1000-8000-00805f9b34fb"
 AVEA_SERVICE_UUID = "f815e810-456c-6761-746f-4d756e696368"
 CONTROL_CHARACTERISTIC_UUID = "f815e811-456c-6761-746f-4d756e696368"
 MAX_TRANSITION_FPS = 5
@@ -41,6 +42,7 @@ class Bulb:
         self.addr = address
         self.name = "Unknown"
         self.fw_version = "Unknown"
+        self.manufacturer_name = "Unknown"
         self.red = 0
         self.blue = 0
         self.green = 0
@@ -253,6 +255,30 @@ class Bulb:
             )
             return ""
 
+    async def _read_manufacturer_name(self) -> str:
+        if not self._client:
+            return ""
+        try:
+            payload = await self._client.read_gatt_char(MANUFACTURER_NAME_UUID)
+        except (BleakError, AttributeError, OSError):
+            _LOGGER.warning(
+                "Could not read manufacturer name from bulb %s",
+                self.addr,
+                exc_info=True,
+            )
+            return ""
+        if isinstance(payload, bytearray):
+            payload = bytes(payload)
+        try:
+            return payload.decode("utf-8")
+        except UnicodeDecodeError:
+            _LOGGER.warning(
+                "Could not decode manufacturer name from bulb %s",
+                self.addr,
+                exc_info=True,
+            )
+            return ""
+
     async def _smooth_transition(
         self,
         red_table: Sequence[int],
@@ -302,6 +328,19 @@ class Bulb:
                 self.disconnect()
         result = value if isinstance(value, str) else ""
         self.fw_version = result
+        return result
+
+    def get_manufacturer_name(self) -> str:
+        with self._op_lock:
+            already_connected = self._is_connected()
+            if not already_connected and not self.connect():
+                self.manufacturer_name = ""
+                return ""
+            value = self._submit(self._read_manufacturer_name())
+            if not already_connected:
+                self.disconnect()
+        result = value if isinstance(value, str) else ""
+        self.manufacturer_name = result
         return result
 
     def set_brightness(self, brightness):

--- a/avea/avea.py
+++ b/avea/avea.py
@@ -270,7 +270,7 @@ class Bulb:
         if isinstance(payload, bytearray):
             payload = bytes(payload)
         try:
-            return payload.decode("utf-8")
+            return payload.decode("utf-8").rstrip("\x00")
         except UnicodeDecodeError:
             _LOGGER.warning(
                 "Could not decode manufacturer name from bulb %s",

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -52,7 +52,7 @@ class LoggingTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_read_manufacturer_name_reads_expected_uuid(self):
         bulb = Bulb("00:11:22:33:44:55")
-        bulb._client = FirmwareClient(payload=bytearray(b"Elgato Systems GmbH"))
+        bulb._client = FirmwareClient(payload=bytearray(b"Elgato Systems GmbH\x00"))
 
         self.assertEqual(await bulb._read_manufacturer_name(), "Elgato Systems GmbH")
         self.assertEqual(bulb._client.uuid, MANUFACTURER_NAME_UUID)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -3,15 +3,17 @@ from unittest.mock import Mock
 
 from bleak.exc import BleakError
 
-from avea.avea import Bulb, check_bounds
+from avea.avea import Bulb, MANUFACTURER_NAME_UUID, check_bounds
 
 
 class FirmwareClient:
     def __init__(self, payload=None, error=None):
         self.payload = payload
         self.error = error
+        self.uuid = None
 
-    async def read_gatt_char(self, _uuid):
+    async def read_gatt_char(self, uuid):
+        self.uuid = uuid
         if self.error:
             raise self.error
         return self.payload
@@ -47,6 +49,31 @@ class LoggingTests(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(await bulb._read_firmware_version(), "")
 
         self.assertIn("Could not decode firmware version", "\n".join(logs.output))
+
+    async def test_read_manufacturer_name_reads_expected_uuid(self):
+        bulb = Bulb("00:11:22:33:44:55")
+        bulb._client = FirmwareClient(payload=bytearray(b"Elgato Systems GmbH"))
+
+        self.assertEqual(await bulb._read_manufacturer_name(), "Elgato Systems GmbH")
+        self.assertEqual(bulb._client.uuid, MANUFACTURER_NAME_UUID)
+
+    async def test_read_manufacturer_name_logs_bleak_error(self):
+        bulb = Bulb("00:11:22:33:44:55")
+        bulb._client = FirmwareClient(error=BleakError("read failed"))
+
+        with self.assertLogs("avea.avea", level="WARNING") as logs:
+            self.assertEqual(await bulb._read_manufacturer_name(), "")
+
+        self.assertIn("Could not read manufacturer name", "\n".join(logs.output))
+
+    async def test_read_manufacturer_name_logs_decode_error(self):
+        bulb = Bulb("00:11:22:33:44:55")
+        bulb._client = FirmwareClient(payload=bytearray(b"\xff"))
+
+        with self.assertLogs("avea.avea", level="WARNING") as logs:
+            self.assertEqual(await bulb._read_manufacturer_name(), "")
+
+        self.assertIn("Could not decode manufacturer name", "\n".join(logs.output))
 
     def test_smooth_transition_masks_expected_connection_error(self):
         bulb = Bulb("00:11:22:33:44:55")


### PR DESCRIPTION
## Summary
- Add `get_manufacturer_name()` to read the Avea bulb Manufacturer Name String via BLE Device Information Service.
- Mirror the existing firmware-version read behavior for UUID constants, async read helper, synchronous accessor, connection reuse, caching, defaults, and error handling.
- Document the new accessor in the README usage example.

## Tests
- `.venv/bin/pytest` → `9 passed`