### PR TITLE
Add hardware revision string accessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ theRgbColor = myBulb.get_rgb()          # Query the bulb in a RGB format
 theBrightness = myBulb.get_brightness() # query the current brightness
 theAddr = myBulb.addr                   # query the bulb Bluetooth addr
 theFwVersion = myBulb.get_fw_version()  # query the bulb firmware version
+theHardwareRevision = myBulb.get_hardware_revision()  # query the bulb hardware revision
 theManufacturerName = myBulb.get_manufacturer_name()  # query the bulb manufacturer name
 ```
 

--- a/avea/avea.py
+++ b/avea/avea.py
@@ -26,6 +26,7 @@ __all__ = [
 ]
 
 FIRMWARE_REVISION_UUID = "00002a26-0000-1000-8000-00805f9b34fb"
+HARDWARE_REVISION_UUID = "00002a27-0000-1000-8000-00805f9b34fb"
 MANUFACTURER_NAME_UUID = "00002a29-0000-1000-8000-00805f9b34fb"
 AVEA_SERVICE_UUID = "f815e810-456c-6761-746f-4d756e696368"
 CONTROL_CHARACTERISTIC_UUID = "f815e811-456c-6761-746f-4d756e696368"
@@ -42,6 +43,7 @@ class Bulb:
         self.addr = address
         self.name = "Unknown"
         self.fw_version = "Unknown"
+        self.hardware_revision = "Unknown"
         self.manufacturer_name = "Unknown"
         self.red = 0
         self.blue = 0
@@ -255,6 +257,30 @@ class Bulb:
             )
             return ""
 
+    async def _read_hardware_revision(self) -> str:
+        if not self._client:
+            return ""
+        try:
+            payload = await self._client.read_gatt_char(HARDWARE_REVISION_UUID)
+        except (BleakError, AttributeError, OSError):
+            _LOGGER.warning(
+                "Could not read hardware revision from bulb %s",
+                self.addr,
+                exc_info=True,
+            )
+            return ""
+        if isinstance(payload, bytearray):
+            payload = bytes(payload)
+        try:
+            return payload.decode("utf-8").rstrip("\x00")
+        except UnicodeDecodeError:
+            _LOGGER.warning(
+                "Could not decode hardware revision from bulb %s",
+                self.addr,
+                exc_info=True,
+            )
+            return ""
+
     async def _read_manufacturer_name(self) -> str:
         if not self._client:
             return ""
@@ -328,6 +354,19 @@ class Bulb:
                 self.disconnect()
         result = value if isinstance(value, str) else ""
         self.fw_version = result
+        return result
+
+    def get_hardware_revision(self) -> str:
+        with self._op_lock:
+            already_connected = self._is_connected()
+            if not already_connected and not self.connect():
+                self.hardware_revision = ""
+                return ""
+            value = self._submit(self._read_hardware_revision())
+            if not already_connected:
+                self.disconnect()
+        result = value if isinstance(value, str) else ""
+        self.hardware_revision = result
         return result
 
     def get_manufacturer_name(self) -> str:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock
 
 from bleak.exc import BleakError
 
-from avea.avea import Bulb, MANUFACTURER_NAME_UUID, check_bounds
+from avea.avea import Bulb, HARDWARE_REVISION_UUID, MANUFACTURER_NAME_UUID, check_bounds
 
 
 class FirmwareClient:
@@ -49,6 +49,31 @@ class LoggingTests(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(await bulb._read_firmware_version(), "")
 
         self.assertIn("Could not decode firmware version", "\n".join(logs.output))
+
+    async def test_read_hardware_revision_reads_expected_uuid(self):
+        bulb = Bulb("00:11:22:33:44:55")
+        bulb._client = FirmwareClient(payload=bytearray(b"Elgato Avea\x00"))
+
+        self.assertEqual(await bulb._read_hardware_revision(), "Elgato Avea")
+        self.assertEqual(bulb._client.uuid, HARDWARE_REVISION_UUID)
+
+    async def test_read_hardware_revision_logs_bleak_error(self):
+        bulb = Bulb("00:11:22:33:44:55")
+        bulb._client = FirmwareClient(error=BleakError("read failed"))
+
+        with self.assertLogs("avea.avea", level="WARNING") as logs:
+            self.assertEqual(await bulb._read_hardware_revision(), "")
+
+        self.assertIn("Could not read hardware revision", "\n".join(logs.output))
+
+    async def test_read_hardware_revision_logs_decode_error(self):
+        bulb = Bulb("00:11:22:33:44:55")
+        bulb._client = FirmwareClient(payload=bytearray(b"\xff"))
+
+        with self.assertLogs("avea.avea", level="WARNING") as logs:
+            self.assertEqual(await bulb._read_hardware_revision(), "")
+
+        self.assertIn("Could not decode hardware revision", "\n".join(logs.output))
 
     async def test_read_manufacturer_name_reads_expected_uuid(self):
         bulb = Bulb("00:11:22:33:44:55")


### PR DESCRIPTION
## Summary

Adds support for reading the BLE Device Information Service Hardware Revision String characteristic from Avea bulbs.

## Changes

- Adds `HARDWARE_REVISION_UUID` for characteristic `00002a27-0000-1000-8000-00805f9b34fb`.
- Adds `Bulb.hardware_revision` and `Bulb.get_hardware_revision()` following the existing firmware/manufacturer metadata accessor pattern.
- Normalizes the hardware revision response by stripping a terminating NUL byte observed on real hardware.
- Documents the new accessor in the README usage example.
- Adds tests for the UUID read path, BLE read errors, and UTF-8 decode errors.

## Validation

- `.venv/bin/python -m unittest discover -s tests`: 12 tests passed.
- Verified against a real Avea bulb: `get_hardware_revision()` returned `"Elgato Avea"`.
- Unit tests also passed in the hardware validation environment.