### PR TITLE
Trim BLE string NUL terminators

### DIFF
--- a/avea/avea.py
+++ b/avea/avea.py
@@ -244,7 +244,7 @@ class Bulb:
         if isinstance(payload, bytearray):
             payload = bytes(payload)
         try:
-            return payload.decode("utf-8")
+            return payload.decode("utf-8").rstrip("\x00")
         except UnicodeDecodeError:
             _LOGGER.warning(
                 "Could not decode firmware version from bulb %s",
@@ -458,7 +458,7 @@ class Bulb:
 
         elif cmd == 0x58:
             try:
-                self.name = values.decode("utf-8")
+                self.name = values.decode("utf-8").rstrip("\x00")
             except UnicodeDecodeError:
                 _LOGGER.warning(
                     "Could not decode bulb name notification for bulb %s",

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -48,6 +48,19 @@ class LoggingTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertIn("Could not decode firmware version", "\n".join(logs.output))
 
+    async def test_read_firmware_version_strips_trailing_nul(self):
+        bulb = Bulb("00:11:22:33:44:55")
+        bulb._client = FirmwareClient(payload=bytearray(b"1.1.2.328Bf\x00"))
+
+        self.assertEqual(await bulb._read_firmware_version(), "1.1.2.328Bf")
+
+    def test_process_name_notification_strips_trailing_nul(self):
+        bulb = Bulb("00:11:22:33:44:55")
+
+        bulb.process_notification(b"\x58Fado\x00")
+
+        self.assertEqual(bulb.name, "Fado")
+
     def test_smooth_transition_masks_expected_connection_error(self):
         bulb = Bulb("00:11:22:33:44:55")
         bulb.get_color = Mock(side_effect=BleakError("not connected"))


### PR DESCRIPTION
## Summary
- Trim trailing NUL bytes from firmware revision reads.
- Trim trailing NUL bytes from bulb name notifications.
- Add focused regression tests for both string paths.

## Why
Some Avea hardware returns UTF-8 strings with a terminating `\x00`. These values should be normalized consistently with existing BLE string handling.

## Validation
- `.venv/bin/python -m pytest tests/test_logging.py`: passed
- Hardware test environment: focused test suite passed
- Real hardware validation confirmed both affected string reads are returned without trailing NUL bytes