### PR TITLE
Adjust Dependabot action update PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,4 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    open-pull-requests-limit: 2
-    groups:
-      github-actions:
-        patterns:
-          - "*"
+    open-pull-requests-limit: 3


### PR DESCRIPTION
## Summary

- Remove the GitHub Actions Dependabot group so each action update gets its own PR.
- Raise the open Dependabot PR limit from 2 to 3 so the current action updates can appear separately in parallel.

## Context

Dependabot PR #33 grouped `actions/checkout`, `actions/setup-python`, and `actions/ai-inference` into one update. Keeping action updates separate makes each version bump easier to review and merge independently.

## Validation

- Parsed `.github/dependabot.yml` with Ruby's YAML loader.