### PR TITLE
Run publish workflow only for published releases

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,11 +1,11 @@
-# This workflow will upload a Python Package using Twine when a release is created or published
+# This workflow will upload a Python Package using Twine when a release is published
 # For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
 
 name: Upload Python Package
 
 on:
   release:
-    types: [created, published]
+    types: [published]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

- Change the Python publish workflow to run only for the `published` release event.
- Keep the manual `workflow_dispatch` trigger.

## Why

The workflow currently listens to both `created` and `published`, so publishing a release can trigger duplicate package upload runs for the same tag.

## Scope

- Workflow trigger only.
- No package, library, version, or release-note changes.

## Tests

- Not run; YAML trigger-only change.