### PR TITLE
Fix firmware version formatting

### DIFF
--- a/avea/avea.py
+++ b/avea/avea.py
@@ -7,6 +7,7 @@ Source  : https://github.com/k0rventen/avea
 import asyncio
 import logging
 import math
+import re
 import threading
 from contextlib import suppress
 from typing import Awaitable, Callable, Optional, Sequence
@@ -34,6 +35,15 @@ MAX_TRANSITION_FPS = 5
 
 
 _LOGGER = logging.getLogger(__name__)
+_FW_VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)\.(\d+)")
+
+
+def _format_firmware_version(value: str) -> str:
+    match = _FW_VERSION_RE.match(value)
+    if not match:
+        return value
+    major, minor, patch, build = match.groups()
+    return f"{major}.{minor}.{patch} ({build})"
 
 
 class Bulb:
@@ -352,7 +362,7 @@ class Bulb:
             value = self._submit(self._read_firmware_version())
             if not already_connected:
                 self.disconnect()
-        result = value if isinstance(value, str) else ""
+        result = _format_firmware_version(value) if isinstance(value, str) else ""
         self.fw_version = result
         return result
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -3,7 +3,13 @@ from unittest.mock import Mock
 
 from bleak.exc import BleakError
 
-from avea.avea import Bulb, HARDWARE_REVISION_UUID, MANUFACTURER_NAME_UUID, check_bounds
+from avea.avea import (
+    Bulb,
+    FIRMWARE_REVISION_UUID,
+    HARDWARE_REVISION_UUID,
+    MANUFACTURER_NAME_UUID,
+    check_bounds,
+)
 
 
 class FirmwareClient:
@@ -11,12 +17,19 @@ class FirmwareClient:
         self.payload = payload
         self.error = error
         self.uuid = None
+        self.is_connected = True
 
     async def read_gatt_char(self, uuid):
         self.uuid = uuid
         if self.error:
             raise self.error
         return self.payload
+
+    async def stop_notify(self, uuid):
+        return None
+
+    async def disconnect(self):
+        self.is_connected = False
 
 
 class LoggingTests(unittest.IsolatedAsyncioTestCase):
@@ -55,6 +68,30 @@ class LoggingTests(unittest.IsolatedAsyncioTestCase):
         bulb._client = FirmwareClient(payload=bytearray(b"firmware-version\x00"))
 
         self.assertEqual(await bulb._read_firmware_version(), "firmware-version")
+
+    def test_get_fw_version_formats_app_version(self):
+        bulb = Bulb("00:11:22:33:44:55")
+        bulb._client = FirmwareClient(payload=bytearray(b"1.1.2.328Bf"))
+
+        self.assertEqual(bulb.get_fw_version(), "1.1.2 (328)")
+        self.assertEqual(bulb.fw_version, "1.1.2 (328)")
+        self.assertEqual(bulb._client.uuid, FIRMWARE_REVISION_UUID)
+        bulb.close()
+
+    def test_get_fw_version_formats_numeric_build(self):
+        bulb = Bulb("00:11:22:33:44:55")
+        bulb._client = FirmwareClient(payload=bytearray(b"1.1.2.328"))
+
+        self.assertEqual(bulb.get_fw_version(), "1.1.2 (328)")
+        bulb.close()
+
+    def test_get_fw_version_keeps_unknown_format(self):
+        bulb = Bulb("00:11:22:33:44:55")
+        bulb._client = FirmwareClient(payload=bytearray(b"firmware-version"))
+
+        self.assertEqual(bulb.get_fw_version(), "firmware-version")
+        self.assertEqual(bulb.fw_version, "firmware-version")
+        bulb.close()
 
     def test_process_name_notification_strips_trailing_nul(self):
         bulb = Bulb("00:11:22:33:44:55")


### PR DESCRIPTION
## Summary
- Format Avea firmware revision strings returned by `get_fw_version()` to match the official app display.
- Convert values like `1.1.2.328Bf` to `1.1.2 (328)` while leaving unknown formats unchanged.
- Keep `bulb.fw_version` aligned with the corrected public return value.
- Fixes #25

## Validation
- `.venv/bin/python -m pytest` -> 17 passed
- Hardware test environment: unit tests passed
- Real Avea hardware check: raw firmware `1.1.2.328Bf`, `get_fw_version()` returned `1.1.2 (328)`