### PR TITLE
Add Avea serial number accessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ theRgbColor = myBulb.get_rgb()          # Query the bulb in a RGB format
 theBrightness = myBulb.get_brightness() # query the current brightness
 theAddr = myBulb.addr                   # query the bulb Bluetooth addr
 theFwVersion = myBulb.get_fw_version()  # query the bulb firmware version
+theSerialNumber = myBulb.get_serial_number()  # query the bulb serial number
 theHardwareRevision = myBulb.get_hardware_revision()  # query the bulb hardware revision
 theManufacturerName = myBulb.get_manufacturer_name()  # query the bulb manufacturer name
 ```

--- a/avea/avea.py
+++ b/avea/avea.py
@@ -27,6 +27,7 @@ __all__ = [
 ]
 
 FIRMWARE_REVISION_UUID = "00002a26-0000-1000-8000-00805f9b34fb"
+SERIAL_NUMBER_UUID = "00002a25-0000-1000-8000-00805f9b34fb"
 HARDWARE_REVISION_UUID = "00002a27-0000-1000-8000-00805f9b34fb"
 MANUFACTURER_NAME_UUID = "00002a29-0000-1000-8000-00805f9b34fb"
 AVEA_SERVICE_UUID = "f815e810-456c-6761-746f-4d756e696368"
@@ -53,6 +54,7 @@ class Bulb:
         self.addr = address
         self.name = "Unknown"
         self.fw_version = "Unknown"
+        self.serial_number = "Unknown"
         self.hardware_revision = "Unknown"
         self.manufacturer_name = "Unknown"
         self.red = 0
@@ -267,6 +269,30 @@ class Bulb:
             )
             return ""
 
+    async def _read_serial_number(self) -> str:
+        if not self._client:
+            return ""
+        try:
+            payload = await self._client.read_gatt_char(SERIAL_NUMBER_UUID)
+        except (BleakError, AttributeError, OSError):
+            _LOGGER.warning(
+                "Could not read serial number from bulb %s",
+                self.addr,
+                exc_info=True,
+            )
+            return ""
+        if isinstance(payload, bytearray):
+            payload = bytes(payload)
+        try:
+            return payload.decode("utf-8").split("\x00", 1)[0]
+        except UnicodeDecodeError:
+            _LOGGER.warning(
+                "Could not decode serial number from bulb %s",
+                self.addr,
+                exc_info=True,
+            )
+            return ""
+
     async def _read_hardware_revision(self) -> str:
         if not self._client:
             return ""
@@ -364,6 +390,21 @@ class Bulb:
                 self.disconnect()
         result = _format_firmware_version(value) if isinstance(value, str) else ""
         self.fw_version = result
+        return result
+
+    def get_serial_number(self) -> str:
+        with self._op_lock:
+            already_connected = self._is_connected()
+            if not already_connected and not self.connect():
+                self.serial_number = ""
+                return ""
+            try:
+                value = self._submit(self._read_serial_number())
+            finally:
+                if not already_connected:
+                    self.disconnect()
+        result = value if isinstance(value, str) else ""
+        self.serial_number = result
         return result
 
     def get_hardware_revision(self) -> str:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -8,6 +8,7 @@ from avea.avea import (
     FIRMWARE_REVISION_UUID,
     HARDWARE_REVISION_UUID,
     MANUFACTURER_NAME_UUID,
+    SERIAL_NUMBER_UUID,
     check_bounds,
 )
 
@@ -99,6 +100,60 @@ class LoggingTests(unittest.IsolatedAsyncioTestCase):
         bulb.process_notification(b"\x58test-bulb\x00")
 
         self.assertEqual(bulb.name, "test-bulb")
+
+    async def test_read_serial_number_reads_expected_uuid(self):
+        bulb = Bulb("00:11:22:33:44:55")
+        bulb._client = FirmwareClient(payload=bytearray(b"ABC123\x00"))
+
+        self.assertEqual(await bulb._read_serial_number(), "ABC123")
+        self.assertEqual(bulb._client.uuid, SERIAL_NUMBER_UUID)
+
+    async def test_read_serial_number_strips_extra_nuls(self):
+        bulb = Bulb("00:11:22:33:44:55")
+        bulb._client = FirmwareClient(payload=bytearray(b"ABC123\x00\x00"))
+
+        self.assertEqual(await bulb._read_serial_number(), "ABC123")
+
+    async def test_read_serial_number_strips_at_first_nul(self):
+        bulb = Bulb("00:11:22:33:44:55")
+        bulb._client = FirmwareClient(payload=bytearray(b"ABC123\x00junk"))
+
+        self.assertEqual(await bulb._read_serial_number(), "ABC123")
+
+    async def test_read_serial_number_logs_bleak_error(self):
+        bulb = Bulb("00:11:22:33:44:55")
+        bulb._client = FirmwareClient(error=BleakError("read failed"))
+
+        with self.assertLogs("avea.avea", level="WARNING") as logs:
+            self.assertEqual(await bulb._read_serial_number(), "")
+
+        self.assertIn("Could not read serial number", "\n".join(logs.output))
+
+    async def test_read_serial_number_logs_decode_error(self):
+        bulb = Bulb("00:11:22:33:44:55")
+        bulb._client = FirmwareClient(payload=bytearray(b"\xff"))
+
+        with self.assertLogs("avea.avea", level="WARNING") as logs:
+            self.assertEqual(await bulb._read_serial_number(), "")
+
+        self.assertIn("Could not decode serial number", "\n".join(logs.output))
+
+    def test_get_serial_number_caches_result(self):
+        bulb = Bulb("00:11:22:33:44:55")
+        bulb._client = FirmwareClient(payload=bytearray(b"ABC123"))
+
+        self.assertEqual(bulb.get_serial_number(), "ABC123")
+        self.assertEqual(bulb.serial_number, "ABC123")
+        self.assertEqual(bulb._client.uuid, SERIAL_NUMBER_UUID)
+        bulb.close()
+
+    def test_get_serial_number_returns_empty_when_connection_fails(self):
+        bulb = Bulb("00:11:22:33:44:55")
+        bulb.serial_number = "Unknown"
+        bulb.connect = Mock(return_value=False)
+
+        self.assertEqual(bulb.get_serial_number(), "")
+        self.assertEqual(bulb.serial_number, "")
 
     async def test_read_hardware_revision_reads_expected_uuid(self):
         bulb = Bulb("00:11:22:33:44:55")


### PR DESCRIPTION
## Summary

Closes #7.

This adds a public `Bulb.get_serial_number()` method for reading an Avea bulb's Serial Number String from the standard Bluetooth Device Information characteristic `0x2A25`.

## Changes

- Add `SERIAL_NUMBER_UUID` for the BLE Serial Number String characteristic.
- Add `Bulb.serial_number` as the cached public attribute.
- Add `_read_serial_number()` and `get_serial_number()` following the existing firmware, hardware revision, and manufacturer name reader pattern.
- Normalize serial number values at the first NUL byte so trailing or embedded terminators do not leak into the returned string.
- Document `get_serial_number()` in the README usage example.
- Add unit coverage for UUID selection, caching, NUL handling, read errors, and decode errors.

## Validation

- Local unit tests passed.
- Hardware test environment unit tests passed.
- Real Avea hardware verification passed: a raw `0x2A25` read matched `get_serial_number()`, and the Device Information manufacturer read matched the expected manufacturer string.