### PR TITLE
Update Python version classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,8 @@ setuptools.setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "License :: OSI Approved :: MIT License",
         "Operating System :: POSIX :: Linux",
     ],


### PR DESCRIPTION
## Summary

- Add PyPI classifiers for Python 3.13 and 3.14
- Keep `python_requires=">=3.10,<4"` unchanged

## Rationale

The CI matrix already tests Python 3.10 through 3.14, but the package metadata only advertised support through Python 3.12. This aligns the published PyPI classifiers with the versions currently validated in CI without broadening the support promise beyond the tested versions.

## Validation

- `.venv/bin/python -m pytest`
- `24 passed` on Python 3.14.5