### PR TITLE
Adapt AI PR note workflow for fork PRs

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -27,14 +27,10 @@ jobs:
         id: diff
         run: |
           gh pr diff "$PR_NUMBER" --repo "$REPO" > pr.diff
-          gh pr view "$PR_NUMBER" --repo "$REPO" --json files --jq '.files[].path' > changed-files.txt
           {
             echo 'diff<<EOF'
             head -c 18000 pr.diff
             echo
-            echo 'EOF'
-            echo 'files<<EOF'
-            head -n 40 changed-files.txt
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
         env:
@@ -92,40 +88,24 @@ jobs:
         uses: actions/ai-inference@v2
         with:
           prompt: |
-            Review this PR using only the title, body, changed files, diff, and nearby context below. Return a neutral maintainer note, not a Copilot-style code review.
+            Review this PR using the diff and nearby context. Give maintainer feedback only when supported by that text.
 
-            Hard rules:
-            - Use exactly these sections, in this order: **Changed files**, **Summary**, **Scope**, **Notes**.
-            - Do not include a **Strengths** section or praise such as "well documented", "good", "excellent", "nice", or "solid".
-            - Do not include empty categories.
-            - Do not say "No security issues found", "No bugs found", "No serious issues", or similar generic reassurance.
-            - For documentation-only PRs, do not invent runtime bugs.
-            - Do not flag downstream clamping when the diff/context shows values are clamped before that call. If relevant, prefer a docstring note like: "expects values already clamped".
-            - Keep the whole answer under 900 characters.
+            Focus: correctness, code quality, maintainability, tests, documentation/API clarity. Avoid praise and speculation. If no concrete note is supported, say: No concrete follow-up notes.
 
             Format:
-            **Changed files**
-            - List up to five changed files from the input. If there are more, add one final "- ..." line.
-
             **Summary**
             One sentence.
 
-            **Scope**
-            One short sentence describing the affected area.
+            **Review notes**
+            - Up to two concrete notes, or exactly: No concrete follow-up notes.
 
-            **Notes**
-            Up to two very short bullets only for concrete follow-up notes supported by the diff/context. If there are none, write exactly: No concrete follow-up notes.
+            Include a **Risk** section only when the diff/context shows a concrete runtime, compatibility, CI, or test risk.
 
             Title:
             ${{ github.event.pull_request.title }}
 
             Body:
             ${{ github.event.pull_request.body }}
-
-            Changed files:
-            ```
-            ${{ steps.diff.outputs.files }}
-            ```
 
             Diff:
             ```diff
@@ -145,39 +125,18 @@ jobs:
 
           python - <<'PY'
           from pathlib import Path
-          import re
-
           marker = '<!-- ai-pr-note -->'
           heading = '## AI pull request note'
-          max_chars = 1200
-          trailer = '\n\n_Output shortened by workflow._\n'
+          max_chars = 2200
           response = Path('ai-response.md').read_text().strip()
-
-          if response:
-              response = re.sub(r'(?is)\n?\*\*Strengths\*\*.*?(?=\n\*\*[^*]+\*\*|\Z)', '', response).strip()
-              forbidden = re.compile(
-                  r'^\s*[-*]?\s*(No security issues found|No bugs found|No serious issues)\.?\s*$',
-                  re.IGNORECASE,
-              )
-              response = '\n'.join(
-                  line for line in response.splitlines() if not forbidden.match(line)
-              ).strip()
-
           if not response:
-              response = '**Changed files**\n- Not available\n\n**Summary**\nNo summary returned.\n\n**Scope**\nNot available.\n\n**Notes**\nNo concrete follow-up notes.'
-
+              response = '**Summary**\nNo summary returned.\n\n**Review notes**\nNo concrete follow-up notes.'
           body = f'{marker}\n{heading}\n\n{response}\n'
           if len(body) > max_chars:
-              available = max_chars - len(trailer)
-              snippet = body[:available]
-              boundaries = [snippet.rfind('\n\n'), snippet.rfind('\n- '), snippet.rfind('. '), snippet.rfind('.\n')]
-              cut = max(boundaries)
-              if cut > 200:
-                  body = snippet[:cut + 1].strip()
-              else:
-                  body = snippet.rstrip()
-              body = body.rstrip(' ,;:-') + trailer
-
+              snippet = body[:max_chars]
+              cut = max(snippet.rfind('\n\n'), snippet.rfind('\n- '), snippet.rfind('. '))
+              body = snippet[:cut + 1].strip() if cut > 200 else snippet.rstrip()
+              body += '\n\n_Output shortened by workflow._\n'
           Path('note.md').write_text(body)
           PY
           COMMENT_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \


### PR DESCRIPTION
## Summary

Updates the AI pull request note workflow to use the focused context and prompt behavior from the intended implementation.

## Details

- Replaces the outdated workflow prompt and comment formatting.
- Provides the AI prompt with the PR diff plus nearby line-numbered file context around changed hunks.
- Keeps the workflow limited to one `actions/ai-inference@v2` call and one PR comment.
- Keeps `pull_request_target` support for pull requests from forks.
- Checks out the pull request head explicitly with `persist-credentials: false`.
- Keeps generated notes focused on concrete feedback supported by the diff and context.
- Only includes a risk section when the diff or context shows a concrete runtime, compatibility, CI, or test risk.

## Notes

This keeps the workflow focused on a short maintainer-style PR note rather than a full code review.