### PR TITLE
Add Black formatting check

### DIFF
--- a/.github/workflows/ci-validation.yml
+++ b/.github/workflows/ci-validation.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e . pytest setuptools wheel
+          python -m pip install -e ".[dev]" setuptools wheel
 
       - name: Run tests
         run: python -m pytest

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![CI Validation](https://github.com/k0rventen/avea/actions/workflows/ci-validation.yml/badge.svg)](https://github.com/k0rventen/avea/actions/workflows/ci-validation.yml)
 [![Python Versions](https://img.shields.io/pypi/pyversions/avea.svg)](https://pypi.org/project/avea/)
 [![License](https://img.shields.io/pypi/l/avea.svg)](https://github.com/k0rventen/avea/blob/master/LICENSE)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 
 The [Avea bulb from Elgato](https://www.amazon.co.uk/Elgato-Avea-Dynamic-Light-Android-Smartphone/dp/B00O4EZ11Q) is a light bulb that connects to an iPhone or Android app via Bluetooth.
@@ -15,6 +16,7 @@ Tested on Raspberry Pi 3 and Zero W (with integrated bluetooth).
 - [Control of an Elgato Avea bulb using Python](#control-of-an-elgato-avea-bulb-using-python)
   - [TL;DR](#tldr)
   - [Library usage](#library-usage)
+  - [Development](#development)
   - [Code documentation](#code-documentation)
   - [Reverse engineering of the bulb](#reverse-engineering-of-the-bulb)
   - [Communication protocol](#communication-protocol)
@@ -101,6 +103,27 @@ theManufacturerName = myBulb.get_manufacturer_name()  # query the bulb manufactu
 That's it. Pretty simple.
 
 Check the explanations below for more informations, or check the sources !
+
+
+## Development
+
+Install the development dependencies before running tests locally:
+
+```bash
+python3 -m pip install -e ".[dev]"
+```
+
+Run the test suite, including the Black formatting check:
+
+```bash
+python3 -m pytest
+```
+
+Format the code with Black before opening a pull request:
+
+```bash
+python3 -m black .
+```
 
 
 ## Code documentation

--- a/avea/__init__.py
+++ b/avea/__init__.py
@@ -2,5 +2,6 @@
 
 A python library to control Elgato's Avea Bulb.
 """
+
 __version__ = "1.8.0"
 from .avea import *

--- a/avea/avea.py
+++ b/avea/avea.py
@@ -148,7 +148,9 @@ class Bulb:
         self.process_notification(payload)
         event = self._notification_event
         expected = self._expected_cmd
-        if event is not None and (expected is None or (payload and payload[0] == expected)):
+        if event is not None and (
+            expected is None or (payload and payload[0] == expected)
+        ):
             event.set()
 
     async def _connect(self) -> bool:
@@ -169,9 +171,8 @@ class Bulb:
             if device is None:
                 raise BleakError(f"Device {self.addr} not found")
             self._device = device
-            display_name = (
-                device.name
-                or (self.name if self.name != "Unknown" else self.addr)
+            display_name = device.name or (
+                self.name if self.name != "Unknown" else self.addr
             )
             client = await establish_connection(
                 BleakClient,
@@ -241,7 +242,9 @@ class Bulb:
     # ------------------------------------------------------------------
     # Command helpers
     # ------------------------------------------------------------------
-    async def _write_command(self, payload: bytes, *, with_response: bool = False) -> None:
+    async def _write_command(
+        self, payload: bytes, *, with_response: bool = False
+    ) -> None:
         if not self._client or not self._client.is_connected:
             raise BleakError("Client is not connected")
         await self._client.write_gatt_char(
@@ -265,7 +268,9 @@ class Bulb:
         self._notification_event = event
         self._expected_cmd = expected_cmd
         try:
-            await self._client.write_gatt_char(CONTROL_CHARACTERISTIC_UUID, command, response=False)
+            await self._client.write_gatt_char(
+                CONTROL_CHARACTERISTIC_UUID, command, response=False
+            )
             await asyncio.wait_for(event.wait(), timeout)
         except asyncio.TimeoutError:
             pass
@@ -379,7 +384,9 @@ class Bulb:
         if not self._client or not self._client.is_connected:
             raise BleakError("Client is not connected")
         last_payload = None
-        for index, (r, g, b) in enumerate(zip(red_table, green_table, blue_table), start=1):
+        for index, (r, g, b) in enumerate(
+            zip(red_table, green_table, blue_table), start=1
+        ):
             payload = compute_color(
                 check_bounds(0),
                 check_bounds(r),
@@ -565,7 +572,9 @@ class Bulb:
         with self._op_lock:
             self.set_color(0, red * 16, green * 16, blue * 16)
 
-    def set_smooth_transition(self, target_red, target_green, target_blue, duration=2, fps=60):
+    def set_smooth_transition(
+        self, target_red, target_green, target_blue, duration=2, fps=60
+    ):
         """Fade smoothly from the current color to a target RGB color.
 
         Args:
@@ -705,9 +714,15 @@ class Bulb:
 
         elif cmd == 0x35:
             hex_val = values.hex()
-            self.red = int.from_bytes(bytes.fromhex(hex_val[-4:]), "little") ^ int(0x3000)
-            self.green = int.from_bytes(bytes.fromhex(hex_val[-8:-4]), "little") ^ int(0x2000)
-            self.blue = int.from_bytes(bytes.fromhex(hex_val[-12:-8]), "little") ^ int(0x1000)
+            self.red = int.from_bytes(bytes.fromhex(hex_val[-4:]), "little") ^ int(
+                0x3000
+            )
+            self.green = int.from_bytes(bytes.fromhex(hex_val[-8:-4]), "little") ^ int(
+                0x2000
+            )
+            self.blue = int.from_bytes(bytes.fromhex(hex_val[-12:-8]), "little") ^ int(
+                0x1000
+            )
             self.white = int.from_bytes(bytes.fromhex(hex_val[-16:-12]), "little")
             self._color_known = True
 
@@ -807,6 +822,7 @@ def discover_avea_bulbs(timeout: float = 4.0):
 # ----------------------------------------------------------------------
 # Utility functions
 # ----------------------------------------------------------------------
+
 
 def compute_brightness(brightness):
     """Build the BLE payload for a brightness command.

--- a/example.py
+++ b/example.py
@@ -7,22 +7,22 @@ if len(bulb_list) == 0:
     print("no bulbs found..")
     exit()
 
-print("Found",str(len(bulb_list)),"bulb(s) !")
+print("Found", str(len(bulb_list)), "bulb(s) !")
 
 for bulb in bulb_list:
-    print("Bulb name is : "+bulb.get_name())
+    print("Bulb name is : " + bulb.get_name())
 
     print("Setting to white")
-    bulb.set_rgb(255,255,255)
+    bulb.set_rgb(255, 255, 255)
     time.sleep(2)
 
     print("Now to red")
-    bulb.set_rgb(255,0,0)
+    bulb.set_rgb(255, 0, 0)
     time.sleep(2)
 
     print("And now a smooth transition to blue in 4s at 60fps")
-    bulb.set_smooth_transition(0,0,255,4,60)
+    bulb.set_smooth_transition(0, 0, 255, 4, 60)
     time.sleep(2)
 
     print("Finally, off")
-    bulb.set_rgb(0,0,0)
+    bulb.set_rgb(0, 0, 0)

--- a/setup.py
+++ b/setup.py
@@ -42,5 +42,11 @@ setuptools.setup(
         "bleak>=1.0.0",
         "bleak-retry-connector>=4.0.0",
     ],
+    extras_require={
+        "dev": [
+            "black>=26,<27",
+            "pytest",
+        ],
+    },
     python_requires=">=3.10,<4",
 )

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,0 +1,16 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_black_formatting():
+    root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [sys.executable, "-m", "black", "--check", "."],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
## Summary

- Add Black as the project formatter through the existing development extras
- Run `black --check .` through pytest so local tests and CI enforce formatting
- Update CI to install `.[dev]`
- Add the Black code-style badge and local development commands to the README
- Apply Black's default formatting to the current Python files

Closes #52.

## Validation

- `.venv/bin/python -m pytest`
- `.venv/bin/python -m black --check .`
- `.venv/bin/python setup.py sdist bdist_wheel`